### PR TITLE
Fixed an ugly indentation probelm

### DIFF
--- a/settings/processing-language.cson
+++ b/settings/processing-language.cson
@@ -1,4 +1,4 @@
 '.source.processing':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '^.*(\\^"\'*|\\([^)"\']*)$'
+    'increaseIndentPattern': '^.*(\\[^"\']*|\\([^)"\']*)$'

--- a/settings/processing-language.cson
+++ b/settings/processing-language.cson
@@ -1,4 +1,4 @@
 '.source.processing':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '^.*(\\[^"\']*|\\([^)"\']*)$'
+    'increaseIndentPattern': '^.*(\\^"\'*|\\([^)"\']*)$'

--- a/settings/processing-language.cson
+++ b/settings/processing-language.cson
@@ -1,4 +1,4 @@
 '.source.processing':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '^.*(\\{[^}"\']*|\\([^)"\']*)$'
+    'increaseIndentPattern': '^.*(\\[^"\']*|\\([^)"\']*)$'


### PR DESCRIPTION
A tab space was constantly occurring after if, for, while and other
statements.

Before: http://i.imgur.com/4Z8NNnW.gifv

After: http://i.imgur.com/qYTl3T1.gifv
